### PR TITLE
Add product, v, via parameters to redirect_uri

### DIFF
--- a/lib/ueberauth/strategy/auth0.ex
+++ b/lib/ueberauth/strategy/auth0.ex
@@ -99,6 +99,11 @@ defmodule Ueberauth.Strategy.Auth0 do
       |> option(:allowed_request_params)
       |> Enum.map(&to_string/1)
 
+    # TODO: make a proper API to allow specifying which params are allowed
+    query_params = conn.params
+      |> Map.take(["product", "via", "v"])
+      |> Map.to_list()
+
     opts =
       conn.params
       |> maybe_replace_param(conn, "scope", :default_scope)
@@ -114,7 +119,7 @@ defmodule Ueberauth.Strategy.Auth0 do
       # Remove empty params
       |> Enum.reject(fn {_, v} -> blank?(v) end)
       |> Enum.map(fn {k, v} -> {String.to_existing_atom(k), v} end)
-      |> Keyword.put(:redirect_uri, callback_url(conn))
+      |> Keyword.put(:redirect_uri, callback_url(conn, query_params))
 
     module = option(conn, :oauth2_module)
 

--- a/test/strategy/auth0_test.exs
+++ b/test/strategy/auth0_test.exs
@@ -95,6 +95,17 @@ defmodule Ueberauth.Strategy.Auth0Test do
       assert conn.resp_body =~ ~s|organization=org_abc123|
       assert conn.resp_body =~ ~s|invitation=INVITE2022|
     end
+
+    test "hacky parameter test" do
+      conn =
+        :get
+        |> conn("/auth/auth0?v=foo&via=bar&product=baz")
+        |> SpecRouter.call(@router)
+
+      assert conn.resp_body =~
+               ~s|redirect_uri=http%3A%2F%2Fwww.example.com%2Fauth%2Fauth0%2Fcallback%3Fproduct%3Dbaz%26v%3Dfoo%26via%3Dbar|
+    end
+
   end
 
   describe "handle_callback!" do


### PR DESCRIPTION
This adds forwarding of 3 extra parameters (v, via, product).

This is not generically useful. We would like to to extend this later.